### PR TITLE
Avoid error if mysqli or curl extension are not loaded in php.

### DIFF
--- a/plugins/PHP/Plugins/__init__.php
+++ b/plugins/PHP/Plugins/__init__.php
@@ -16,6 +16,16 @@
  ******************************************************************************/
 require_once "Common/PluginsDefines.php";
 
-require_once "Sys/curl/curl.php";// intercept all curl_xxxx
-require_once "Sys/date/date.php";// intercept all date_xxxx
-require_once "Sys/mysqli/mysqli.php";
+// intercept all date_xxxx, part of php core
+require_once "Sys/date/date.php";
+
+// intercept all curl_xxxx, if curl extension is available
+if (function_exists('curl_exec'))
+{
+    require_once "Sys/curl/curl.php";
+}
+
+if (function_exists('mysqli_connect'))
+{
+    require_once "Sys/mysqli/mysqli.php";
+}


### PR DESCRIPTION
One of the error I met was due to the fact that on my php installation `mysqli` is not available. It can also happen the same things with `curl`. Adding test avoid error.