### PR TITLE
Improvements on PerRequestPlugins class

### DIFF
--- a/plugins/PHP/Plugins/PerRequestPlugins.php
+++ b/plugins/PHP/Plugins/PerRequestPlugins.php
@@ -66,14 +66,15 @@ class PerRequestPlugins
 
         if(isset($_SERVER['REMOTE_ADDR'])) {
             pinpoint_add_clue(PP_REQ_CLIENT, $_SERVER["REMOTE_ADDR"]);
-        } elseif (($hostname = gethostname()) !== false) {
-            pinpoint_add_clue(PP_REQ_CLIENT, $hostname);
         }
 
         if(isset($_SERVER['HTTP_HOST'])) {
             pinpoint_add_clue(PP_REQ_SERVER, $_SERVER["HTTP_HOST"]);
-        } elseif(($pid = getmypid()) !== false) {
-            pinpoint_add_clue(PP_REQ_SERVER, sprintf("[pid:%d]", $pid));
+        } elseif(($hostname = gethostname()) !== false) {
+            if(($pid = getmypid()) !== false) {
+                $hostname .= sprintf("[pid:%d]", $pid);
+            }
+            pinpoint_add_clue(PP_REQ_SERVER, $hostname);
         }
 
         $this->app_name = APPLICATION_NAME;


### PR DESCRIPTION
* Give opportunity to extend `PerRequestPlugins`, if we don't need to re-implement everything already inside `PerRequestPlugins` make class use `static` instead of self insiden `instance()`, allow override of constructor and call of it inside child class.
* Add more information when running in CLI by adding hostname and pid of the process.
* Truncate appid to be sure to be in range of 24 characters which is default value on collector side.