### PR TITLE
If log_dir is empty display on console #324

### DIFF
--- a/collector-agent/CollectorAgentConf/CollectorAgentConf.py
+++ b/collector-agent/CollectorAgentConf/CollectorAgentConf.py
@@ -147,7 +147,7 @@ class CollectorAgentConf(object):
 
 
     def _setLog(self, dir, level):
-        if dir is not None:
+        if dir:
             set_logger_file(dir)
         else:
             logger_enable_console()


### PR DESCRIPTION
Pull request related to #324 so if we set `PP_LOG_DIR=""` or `LOG_DIR=''` it will display log on console instead of in a file.