### PR TITLE
fix(check_tracelimit): tracelimit

### DIFF
--- a/common/include/common.h
+++ b/common/include/common.h
@@ -198,7 +198,7 @@ int pinpoint_get_context_long(NodeID _id,const char* key,long*);
 /**
  * if tracelimit enable, check current trace state,
  * @param timestamp
- * @return 1, sampled or else, not sampled
+ * @return 0, sampled or else, not sampled
  */
 int check_tracelimit(int64_t);
 

--- a/common/src/Cache/SafeSharedState.cpp
+++ b/common/src/Cache/SafeSharedState.cpp
@@ -47,15 +47,16 @@ bool SafeSharedState::checkTraceLimit(int64_t timestamp)
     else if(this->_global_state->tick >= global_agent_info.trace_limit)
     {
         goto BLOCK;
-    }else if(this->isReady() == false){
-        goto BLOCK;
+    // note: if offline, just test it in 5secs
+    // }else if(this->isReady() == false){
+    //     goto BLOCK;
     }else
     {
         __sync_add_and_fetch(&this->_global_state->tick,1);
     }
     return false;
 BLOCK:
-    pp_trace("This span dropped. max_trace_limit:%d current_tick:%d offLine:%d",global_agent_info.trace_limit,
+    pp_trace("This span dropped. max_trace_limit:%d current_tick:%d onLine:%d",global_agent_info.trace_limit,
         this->_global_state->tick,this->isReady()?(1):(0));
     return true;
 }

--- a/src/PHP/tests/trace_limit_test-i448.phpt
+++ b/src/PHP/tests/trace_limit_test-i448.phpt
@@ -42,7 +42,7 @@ string(1) "a"
 [pinpoint] [%d] [%d] pinpoint_get_context_key#127 failed with map::at, parameters:not exsit
 bool(false)
 [pinpoint] [%d] [%d]#127 pinpoint_end_trace Done!
-[pinpoint] [%d] [%d]This span dropped. max_trace_limit:0 current_tick:0 offLine:1
+[pinpoint] [%d] [%d]This span dropped. max_trace_limit:0 current_tick:0 onLine:1
 [pinpoint] [%d] [%d]change current#128 status, before:2,now:4
 [pinpoint] [%d] [%d]current#128 span dropped,due to TRACE_BLOCK
 [pinpoint] [%d] [%d]#128 pinpoint_end_trace Done!

--- a/src/PHP/tests/trace_limit_test.phpt
+++ b/src/PHP/tests/trace_limit_test.phpt
@@ -19,5 +19,5 @@ if(pinpoint_tracelimit() || pinpoint_tracelimit() ||pinpoint_tracelimit() || pin
     echo "pinpoint_tracelimit failed";
 }
 --EXPECTF--
-[pinpoint] [%d] [%d]This span dropped. max_trace_limit:2 current_tick:2 offLine:1
+[pinpoint] [%d] [%d]This span dropped. max_trace_limit:2 current_tick:2 onLine:1
 pass

--- a/src/PHP/tests5/trace_limit_test-i448.phpt
+++ b/src/PHP/tests5/trace_limit_test-i448.phpt
@@ -42,7 +42,7 @@ string(1) "a"
 [pinpoint] [%d] [%d] pinpoint_get_context_key#127 failed with map::at, parameters:not exsit
 bool(false)
 [pinpoint] [%d] [%d]#127 pinpoint_end_trace Done!
-[pinpoint] [%d] [%d]This span dropped. max_trace_limit:0 current_tick:0 offLine:1
+[pinpoint] [%d] [%d]This span dropped. max_trace_limit:0 current_tick:0 onLine:1
 [pinpoint] [%d] [%d]change current#128 status, before:2,now:4
 [pinpoint] [%d] [%d]current#128 span dropped,due to TRACE_BLOCK
 [pinpoint] [%d] [%d]#128 pinpoint_end_trace Done!

--- a/src/PHP/tests5/trace_limit_test.phpt
+++ b/src/PHP/tests5/trace_limit_test.phpt
@@ -19,5 +19,5 @@ if(pinpoint_tracelimit() || pinpoint_tracelimit() ||pinpoint_tracelimit() || pin
     echo "pinpoint_tracelimit failed";
 }
 --EXPECTF--
-[pinpoint] [%d] [%d]This span dropped. max_trace_limit:2 current_tick:2 offLine:1
+[pinpoint] [%d] [%d]This span dropped. max_trace_limit:2 current_tick:2 onLine:1
 pass


### PR DESCRIPTION
ignore ready() checking. If not ready, just cache the span