### PR TITLE
[fix] pinpoint_set_context_long leads crash in golang

### DIFF
--- a/common/src/NodePool/PoolManager.cpp
+++ b/common/src/NodePool/PoolManager.cpp
@@ -73,8 +73,9 @@ TraceNode& PoolManager::getNodeById(NodeID id)
         throw std::out_of_range("id should not be 0");
     }
 
-    id--;
     std::lock_guard<std::mutex> _safe(this->_lock);
+    
+    id--;
 
     if(this->nodeIsAlive(id) == false){
         throw std::out_of_range("id is not alive");

--- a/common/src/NodePool/PoolManager.h
+++ b/common/src/NodePool/PoolManager.h
@@ -71,7 +71,7 @@ public:
 private:
     inline bool nodeIsAlive(NodeID id)
     {
-        if(id>0 && id <this->maxId){
+        if(id>=0 && id <this->maxId){
             return this->_aliveNodeSet[id];
         }
         return false;

--- a/common/src/common.cpp
+++ b/common/src/common.cpp
@@ -23,6 +23,7 @@
 #include <map>
 #include <memory>
 #include <thread>
+#include <stdexcept> 
 
 #include "common.h"
 
@@ -424,7 +425,7 @@ void pinpoint_set_context_key(NodeID _id,const char* key,const char* value)
     }
 }
 
-static void do_set_long_key(NodeID _id,const char* key,long l) noexcept
+static void do_set_long_key(NodeID _id,const char* key,long l) 
 {
     TraceNode& node = g_node_pool.getNodeById(_id);
     assert(node.p_root_node);
@@ -444,7 +445,7 @@ void pinpoint_set_context_long(NodeID _id,const char* key,long l)
     catch(const std::runtime_error& ex)
     {
         pp_trace(" %s#%d failed with %s",__func__,_id,ex.what());
-    }catch(const std::exception&ex)
+    }catch(const std::exception& ex)
     {
         pp_trace(" %s#%d failed with %s",__func__,_id,ex.what());
     }
@@ -473,7 +474,7 @@ int pinpoint_get_context_long(NodeID _id,const char* key,long* l)
     catch(const std::runtime_error& ex)
     {
         pp_trace(" %s#%d failed with %s",__func__,_id,ex.what());
-    }catch(const std::exception&ex)
+    }catch(const std::exception& ex)
     {
         pp_trace(" %s#%d failed with %s",__func__,_id,ex.what());
     }

--- a/common/test/test_common.cc
+++ b/common/test/test_common.cc
@@ -131,6 +131,8 @@ TEST(common,context_check)
     EXPECT_STREQ(pinpoint_get_context_key(id,"adfadf"),"fadfaffadf");
 
     pinpoint_set_context_long(id,"1024",1024);
+    pinpoint_set_context_long(0,"1024",1024);
+    pinpoint_set_context_long(1205,"1024",1024);
     long value ;
     EXPECT_EQ(pinpoint_get_context_long(id,"1024",&value),0);
     EXPECT_EQ(value,1024);
@@ -202,6 +204,15 @@ TEST(common,force_end_trace)
 
 TEST(common,version){
     EXPECT_STREQ(pinpoint_agent_version(),AGENT_VERSION);
+}
+
+//./bin/unittest --gtest_filter=common.id_1
+TEST(common,id_1){
+    NodeID id = pinpoint_start_trace(0);
+    for (int i = 0; i < 1280; i++) {
+        id =pinpoint_start_trace(id);
+    }
+    pinpoint_set_context_long(id,"1024",1024);
 }
 
 // int mymatch(char *buf)


### PR DESCRIPTION
* remove noexcept