### PR TITLE
[fix] MongoClientPlugin AttributeError

### DIFF
--- a/plugins/PY/pinpointPy/libs/pymongo/MongoClientPlugin.py
+++ b/plugins/PY/pinpointPy/libs/pymongo/MongoClientPlugin.py
@@ -32,7 +32,10 @@ class MongoClientPlugin(Common.PinTrace):
     def onBefore(self, *args, **kwargs):
         super().onBefore(*args, **kwargs)
         collection = args[0]
-        self.dst = str(collection.__database.address)
+        try:
+            self.dst = str(collection.__database.address)
+        except AttributeError:
+            self.dst = collection.name
         ###############################################################
         pinpoint.add_trace_header(Defines.PP_INTERCEPTOR_NAME, self.getFuncUniqueName())
         pinpoint.add_trace_header(Defines.PP_SERVER_TYPE, Defines.PP_MONGDB_EXE_QUERY)


### PR DESCRIPTION
Fix MongoClientPlugin AttributeError

Env
```
MongoDB: Amazon DocumentDB v3.6.0
pymongo: 4.2.0
flask: 2.0.2
pinpointPy: 1.0.10
```

Error output
```
Traceback (most recent call last):
  File "/opt/mongo_test.py", line 150, in mongo_test
   mongo_collection.find()
  File "/usr/local/lib/python3.8/site-packages/pinpointPy/Common.py", line 64, in pinpointTrace
    raise e
  File "/usr/local/lib/python3.8/site-packages/pinpointPy/Common.py", line 59, in pinpointTrace
    args, kwargs = self.onBefore(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/pinpointPy/libs/pymongo/MongoClientPlugin.py", line 35, in onBefore
    self.dst = str(collection.__database.address)
  File "/usr/local/lib/python3.8/site-packages/pymongo/collection.py", line 269, in __getattr__
    raise AttributeError(
AttributeError: Collection has no attribute '_MongoClientPlugin__database'. To access the collection._MongoClientPlugin__database collection, use database['collection._MongoClientPlugin__database'].
```

Result Screen
![image](https://user-images.githubusercontent.com/49485894/190539717-5fd78029-b2a0-4ed2-b642-8125a50126ab.png)
