### PR TITLE
  fix CommonPlugin semantic problem

### DIFF
--- a/plugins/PY/pinpointPy/Fastapi/AsyCommonPlugin.py
+++ b/plugins/PY/pinpointPy/Fastapi/AsyCommonPlugin.py
@@ -22,8 +22,8 @@ from .. import pinpoint
 
 class CommonPlugin(AsynPinTrace):
 
-    def onBefore(self,traceId, *args, **kwargs):
-        traceId,args,kwargs = super().onBefore(*args, **kwargs)
+    def onBefore(self,parentId, *args, **kwargs):
+        traceId,args,kwargs = super().onBefore(parentId,*args, **kwargs)
         ###############################################################
         pinpoint.add_trace_header(Defines.PP_INTERCEPTOR_NAME, self.getFuncUniqueName(), traceId)
         pinpoint.add_trace_header(Defines.PP_SERVER_TYPE, Defines.PP_REMOTE_METHOD, traceId)

--- a/plugins/PY/pinpointPy/Fastapi/MotorMongo/__init__.py
+++ b/plugins/PY/pinpointPy/Fastapi/MotorMongo/__init__.py
@@ -20,70 +20,15 @@
 # create by eelu
 
 from ...Interceptor import Interceptor,intercept_once
-from pymongo import monitoring
-
-from .. import AsyCommon
-from ... import pinpoint
-from ... import Defines
-
-
-class MotorComandPlugins(AsyCommon.AsynPinTrace):
-
-    def __init__(self, name):
-        super().__init__(name)
-
-    def onBefore(self,parentId,*args, **kwargs):
-        traceId,_,_=super().onBefore(parentId,*args,**kwargs)
-        event = args[0]
-        ###############################################################
-        pinpoint.add_trace_header(Defines.PP_INTERCEPTOR_NAME, event.command_name, traceId)
-        pinpoint.add_trace_header(Defines.PP_SERVER_TYPE, Defines.PP_MONGDB_EXE_QUERY,traceId)
-        pinpoint.add_trace_header(Defines.PP_DESTINATION, event.connection_id[0], traceId)
-        ###############################################################
-        return event
-
-    def onEnd(self,traceId, ret):
-        super().onEnd(traceId,ret)
-        return ret
-
-    def onException(self,traceId, e):
-        pinpoint.add_trace_header(Defines.PP_ADD_EXCEPTION, str(e),traceId)
-
-
-class CommandLogger(monitoring.CommandListener):
-    def __init__(self) -> None:
-        self.CommandPlugins={}
-
-    def started(self, event):
-        sampled,parentId = MotorComandPlugins.isSample()
-        if not sampled:
-            return 
-
-        if event.command_name not in self.CommandPlugins:
-            self.CommandPlugins[event.command_name] = MotorComandPlugins(event.command_name)
-
-        plugin = self.CommandPlugins[event.command_name]
-        plugin.onBefore(parentId,event)
-
-    def succeeded(self, event):
-        sampled,traceId= MotorComandPlugins.isSample()
-        if not sampled:
-            return 
-        plugin = self.CommandPlugins[event.command_name]
-        plugin.onEnd(traceId,None)
-        
-
-    def failed(self, event):
-        sampled,traceId= MotorComandPlugins.isSample()
-        if not sampled:
-            return 
-        plugin = self.CommandPlugins[event.command_name]
-        plugin.onException(traceId,None)  
-        plugin.onEnd(traceId,None)
-
 
 @intercept_once
 def monkey_patch():
-    monitoring.register(CommandLogger())
+    try:
+        from pymongo import monitoring
+        from .motorComandPlugins import CommandLogger
+        monitoring.register(CommandLogger())
+    except ImportError as e:
+        # do nothing
+        print(e)
 
 __all__=['monkey_patch']


### PR DESCRIPTION
missing parentId
`traceId,args,kwargs = super().onBefore(parentId,*args, **kwargs)`