### PR TITLE
report ext ver in phpinfo

### DIFF
--- a/pinpoint_php.cpp
+++ b/pinpoint_php.cpp
@@ -1262,6 +1262,7 @@ PHP_RSHUTDOWN_FUNCTION(pinpoint_php) {
 PHP_MINFO_FUNCTION(pinpoint_php) {
   php_info_print_table_start();
   php_info_print_table_header(2, "pinpoint_php support", "enabled");
+  php_info_print_table_header(2, "pinpoint_php extension version", PHP_PINPOINT_PHP_VERSION);
   php_info_print_table_end();
 
   //    /* Remove comments if you have entries in php.ini


### PR DESCRIPTION
Common practice, useful info (for support)

```
$ php -n -d extension=modules/pinpoint_php.so --ri pinpoint_php

pinpoint_php

pinpoint_php support => enabled
pinpoint_php extension version => 0.5.4

Directive => Local Value => Master Value
pinpoint_php.SendSpanTimeOutMs => 0 => 0
pinpoint_php.CollectorHost => unix:/tmp/collector.sock => unix:/tmp/collector.sock
pinpoint_php.UnitTest => no => no
pinpoint_php.TraceLimit => -1 => -1
pinpoint_php.DebugReport => no => no
```
