### PR TITLE
Fix build warnings

### DIFF
--- a/pinpoint_php.cpp
+++ b/pinpoint_php.cpp
@@ -206,7 +206,7 @@ void (*old_error_cb)(int type, const char *error_filename,
   }
 
 PHP_FUNCTION(_pinpoint_drop_trace) {
-  NodeID id = E_ROOT_NODE, cur_id = E_ROOT_NODE;
+  NodeID id = E_ROOT_NODE;
 #if PHP_VERSION_ID < 70000
   size_t _id = -1;
   zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &_id);

--- a/pinpoint_php.cpp
+++ b/pinpoint_php.cpp
@@ -614,7 +614,7 @@ static inline zend_string *merge_pp_style_name(zend_string *scope,
 #if (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION >= 2)
 
 // ref from php-8.2.19/ext/standard/var.c:137
-static zval *zend_array_index(zval *ar, int index) {
+static zval *zend_array_index(zval *ar, uint32_t index) {
   HashTable *__ht = Z_ARRVAL_P(ar);
   uint32_t _idx = 0;
   uint32_t _count = __ht->nNumUsed - _idx;
@@ -768,7 +768,7 @@ static void replace_ex_caller_parameters(zval *argv) {
     return;
   }
 
-  int size = zend_array_count(Z_ARRVAL_P(argv));
+  uint32_t size = zend_array_count(Z_ARRVAL_P(argv));
   pp_trace("argv size:%d", size);
   uint32_t param_count = ZEND_CALL_NUM_ARGS(EG(current_execute_data));
   if (size != param_count) {
@@ -777,7 +777,7 @@ static void replace_ex_caller_parameters(zval *argv) {
     return;
   }
 
-  int i = 0;
+  uint32_t i = 0;
   zval *ex_param_ptr = ZEND_CALL_ARG(EG(current_execute_data), 1);
 
   // check old and new

--- a/pinpoint_php.cpp
+++ b/pinpoint_php.cpp
@@ -67,7 +67,7 @@ ZEND_GET_MODULE(pinpoint_php)
 #endif
 
 ZEND_DECLARE_MODULE_GLOBALS(pinpoint_php);
-static void pinpoint_log(char *msg);
+//static void pinpoint_log(char *msg);
 
 // clang-format off
 /* {{{ PHP_INI
@@ -1270,6 +1270,7 @@ PHP_MINFO_FUNCTION(pinpoint_php) {
 }
 /* }}} */
 
+/*
 void pinpoint_log(char *msg) {
 #if PHP_VERSION_ID >= 70100
   php_log_err_with_severity(msg, LOG_DEBUG);
@@ -1278,3 +1279,4 @@ void pinpoint_log(char *msg) {
   php_log_err(msg TSRMLS_CC);
 #endif
 }
+*/


### PR DESCRIPTION
To avoid missing real errors hidden by warning flood.

2 [-Wdeprecated-declarations] are not fixed, because in bundled library

```
libtool: compile:  g++ -I. -I/work/GIT/pecl-and-ext/pinpoint -I/work/GIT/pecl-and-ext/pinpoint/include -I/work/GIT/pecl-and-ext/pinpoint/main -I/work/GIT/pecl-and-ext/pinpoint -I/usr/include/php -I/usr/include/php/main -I/usr/include/php/TSRM -I/usr/include/php/Zend -I/usr/include/php/ext -I/usr/include/php/ext/date/lib -I/work/GIT/pecl-and-ext/pinpoint/common/include -I/work/GIT/pecl-and-ext/pinpoint/common/jsoncpp/include -I/work/GIT/pecl-and-ext/pinpoint/common/src -DHAVE_CONFIG_H -O2 -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DZEND_COMPILE_DL_EXT=1 -c /work/GIT/pecl-and-ext/pinpoint/common/jsoncpp/lib_json/json_reader.cpp -MMD -MF common/jsoncpp/lib_json/json_reader.dep -MT common/jsoncpp/lib_json/json_reader.lo  -fPIC -DPIC -o common/jsoncpp/lib_json/.libs/json_reader.o
/work/GIT/pecl-and-ext/pinpoint/common/jsoncpp/lib_json/json_reader.cpp:756:34: warning: 'Reader' is deprecated: Use CharReader and CharReaderBuilder instead. [-Wdeprecated-declarations]
  756 | Reader::Char Reader::getNextChar() {
      |                                  ^
In file included from /work/GIT/pecl-and-ext/pinpoint/common/jsoncpp/lib_json/json_reader.cpp:10:
/work/GIT/pecl-and-ext/pinpoint/common/jsoncpp/include/json/reader.h:37:63: note: declared here
   37 |     "Use CharReader and CharReaderBuilder instead.") JSON_API Reader {
      |                                                               ^~~~~~
/work/GIT/pecl-and-ext/pinpoint/common/jsoncpp/lib_json/json_reader.cpp:810:21: warning: 'Reader' is deprecated: Use CharReader and CharReaderBuilder instead. [-Wdeprecated-declarations]
  810 | std::vector<Reader::StructuredError> Reader::getStructuredErrors() const {
      |                     ^~~~~~~~~~~~~~~
/work/GIT/pecl-and-ext/pinpoint/common/jsoncpp/include/json/reader.h:37:63: note: declared here
   37 |     "Use CharReader and CharReaderBuilder instead.") JSON_API Reader {
      |                                                               ^~~~~~

```