### PR TITLE
fix dict key failed in requests

### DIFF
--- a/plugins/PY/pinpointPy/libs/_requests/NextSpanPlugin.py
+++ b/plugins/PY/pinpointPy/libs/_requests/NextSpanPlugin.py
@@ -46,7 +46,7 @@ class NextSpanPlugin(Common.PinTrace):
 
     def onBefore(self, parentId, *args, **kwargs):
         traceId, _args, _kwargs = super().onBefore(parentId, *args, **kwargs)
-        url = _args[1]
+        url = kwargs.get('url') or args[1]
         target = urlparse(url).netloc
         ###############################################################
         pinpoint.add_trace_header(

--- a/plugins/PY/pinpointPy/libs/_requests/test_case.py
+++ b/plugins/PY/pinpointPy/libs/_requests/test_case.py
@@ -65,6 +65,16 @@ class Test_Case(TestCase):
         httpbin = create_http_bin_response(body.text)
         self.assertIn(Defines.PP_HEADER_PINPOINT_SPANID, httpbin.headers)
 
+    @PinTransaction("testcase", GenTestHeader())
+    def test_request_kwargs(self):
+        import requests
+        parameters = {
+            'method': "POST", "url": 'http://httpbin/anything', "data": 'abc'
+        }
+        body = requests.request(**parameters)
+        httpbin = create_http_bin_response(body.text)
+        self.assertIn(Defines.PP_HEADER_PINPOINT_SPANID, httpbin.headers)
+
     def test_request_no_transaction(self):
         import requests
         from threading import Thread


### PR DESCRIPTION
## Describe your changes
> why we need this pr?

-  add testcase for **parameters
- https://github.com/pinpoint-apm/pinpoint-c-agent/pull/712

`requests.request(**parameters)` exists in many plugins, we will resovled in later version.

## Issue ticket number and link
> if it has issues, add them

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
